### PR TITLE
Migration split

### DIFF
--- a/migrations/2_deploy_sale.js
+++ b/migrations/2_deploy_sale.js
@@ -2,59 +2,6 @@
 
 const Sale = artifacts.require('./Sale.sol');
 const fs = require('fs');
-const BN = require('bn.js');
-
-const distributePreBuyersTokens = async function distributePreBuyersTokens(addresses, tokens) {
-  const BATCHSIZE = 30;
-  if (addresses.length !== tokens.length) {
-    throw new Error('The number of pre-buyers and pre-buyer token allocations do not match');
-  }
-
-  const addressesChunk = addresses.slice(0, BATCHSIZE);
-  const tokensChunk = tokens.slice(0, BATCHSIZE);
-  const sale = await Sale.deployed();
-  await sale.distributePreBuyersRewards(addressesChunk, tokensChunk);
-  console.log(`Distributed tokens to a batch of ${addressesChunk.length} pre-buyers`);
-
-  if (addresses.length <= BATCHSIZE) {
-    return addressesChunk;
-  }
-
-  return addressesChunk.concat(await distributePreBuyersTokens(
-    addresses.slice(BATCHSIZE),
-    tokens.slice(BATCHSIZE),
-  ));
-};
-
-const distributeTimelockedTokens = async function distributeTimeLockedTokens(addresses, tokens,
-  timelocks, periods, logs) {
-  const BATCHSIZE = 4;
-  if (addresses.length !== tokens.length) { // expand
-    throw new Error('The number of pre-buyers and pre-buyer token allocations do not match');
-  }
-
-  const addressesChunk = addresses.slice(0, BATCHSIZE);
-  const tokensChunk = tokens.slice(0, BATCHSIZE);
-  const timelocksChunk = timelocks.slice(0, BATCHSIZE);
-  const periodsChunk = periods.slice(0, BATCHSIZE);
-
-  const sale = await Sale.deployed();
-  const receipt = await sale.distributeTimelockedTokens(addressesChunk, tokensChunk,
-    timelocksChunk, periodsChunk);
-  console.log(`Distributed a batch of ${addressesChunk.length} timelocked token chunks`);
-
-  if (addresses.length <= BATCHSIZE) {
-    return logs.concat(receipt.logs);
-  }
-
-  return distributeTimeLockedTokens(
-    addresses.slice(BATCHSIZE),
-    tokens.slice(BATCHSIZE),
-    timelocks.slice(BATCHSIZE),
-    periods.slice(BATCHSIZE),
-    logs.concat(receipt.logs),
-  );
-};
 
 const flattenTimeLockData = function flattenTimeLockData(timeLockData) {
   const flattenedTimeLockData = {
@@ -85,11 +32,7 @@ module.exports = (deployer) => {
   const tokenConf = JSON.parse(fs.readFileSync('./conf/token.json'));
   const preBuyersConf = JSON.parse(fs.readFileSync('./conf/preBuyers.json'));
   const timelocksConf = JSON.parse(fs.readFileSync('./conf/timelocks.json'));
-
   const preBuyers = Object.keys(preBuyersConf).map(preBuyer => preBuyersConf[preBuyer].address);
-  const preBuyersTokens = Object.keys(preBuyersConf).map(preBuyer =>
-    new BN(preBuyersConf[preBuyer].amount, 10));
-
   const timeLockData = flattenTimeLockData(timelocksConf);
 
   return deployer.deploy(Sale,
@@ -105,20 +48,5 @@ module.exports = (deployer) => {
     preBuyers.length,
     timeLockData.beneficiaries.length,
     saleConf.endBlock,
-  )
-    /*.then(() => distributePreBuyersTokens(preBuyers, preBuyersTokens))
-    .then(() => distributeTimelockedTokens(
-      timeLockData.beneficiaries,
-      timeLockData.allocations,
-      timeLockData.disbursementDates,
-      timeLockData.disbursementPeriods,
-      [],
-    ))*/
-    .then((logs) => {
-      console.log('logs', logs)
-      if (!fs.existsSync('logs')) {
-        fs.mkdirSync('logs');
-      }
-      fs.writeFileSync('logs/logs.json', JSON.stringify(logs, null, 2));
-    });
+  );
 };

--- a/migrations/3_distribute.js
+++ b/migrations/3_distribute.js
@@ -11,7 +11,7 @@ const distributePreBuyersTokens = async function distributePreBuyersTokens(addre
 
   const addressesChunk = addresses.slice(0, BATCHSIZE);
   const tokensChunk = tokens.slice(0, BATCHSIZE);
-  const sale = await Sale.at(saleAddress);
+  const sale = await Sale.deployed();
   await sale.distributePreBuyersRewards(addressesChunk, tokensChunk);
   console.log(`Distributed tokens to a batch of ${addressesChunk.length} pre-buyers`);
 
@@ -38,7 +38,7 @@ const distributeTimelockedTokens = async function distributeTimeLockedTokens(add
   const timelocksChunk = timelocks.slice(0, BATCHSIZE);
   const periodsChunk = periods.slice(0, BATCHSIZE);
 
-  const sale = await Sale.at(saleAddress);
+  const sale = await Sale.deployed();
   const receipt = await sale.distributeTimelockedTokens(addressesChunk, tokensChunk,
     timelocksChunk, periodsChunk);
   console.log(`Distributed a batch of ${addressesChunk.length} timelocked token chunks`);

--- a/migrations/3_distribute.js
+++ b/migrations/3_distribute.js
@@ -1,7 +1,8 @@
+/* global artifacts */
+
 const Sale = artifacts.require('./Sale.sol');
 const fs = require('fs');
 const BN = require('bn.js');
-const saleAddress = '0x2b1c553d6623c23cc90ef7890f85e691a79c28f0';
 
 const distributePreBuyersTokens = async function distributePreBuyersTokens(addresses, tokens) {
   const BATCHSIZE = 20;
@@ -81,8 +82,7 @@ const flattenTimeLockData = function flattenTimeLockData(timeLockData) {
 };
 
 module.exports = (deployer) => {
-  const saleConf = JSON.parse(fs.readFileSync('./conf/sale.json'));
-  const tokenConf = JSON.parse(fs.readFileSync('./conf/token.json'));
+  console.log('deployer', deployer);
   const preBuyersConf = JSON.parse(fs.readFileSync('./conf/preBuyers.json'));
   const timelocksConf = JSON.parse(fs.readFileSync('./conf/timelocks.json'));
 
@@ -93,17 +93,17 @@ module.exports = (deployer) => {
   const timeLockData = flattenTimeLockData(timelocksConf);
 
   distributePreBuyersTokens(preBuyers, preBuyersTokens)
-  .then(() => distributeTimelockedTokens(
-    timeLockData.beneficiaries,
-    timeLockData.allocations,
-    timeLockData.disbursementDates,
-    timeLockData.disbursementPeriods,
-    [],
-  ))
-  .then((logs) => {
-    if (!fs.existsSync('logs_distribution')) {
-      fs.mkdirSync('logs_distribution');
-    }
-    fs.writeFileSync('logs_distribution/logs_distribution.json', JSON.stringify(logs, null, 2));
-  });
+    .then(() => distributeTimelockedTokens(
+      timeLockData.beneficiaries,
+      timeLockData.allocations,
+      timeLockData.disbursementDates,
+      timeLockData.disbursementPeriods,
+      [],
+    ))
+    .then((logs) => {
+      if (!fs.existsSync('logs_distribution')) {
+        fs.mkdirSync('logs_distribution');
+      }
+      fs.writeFileSync('logs_distribution/logs_distribution.json', JSON.stringify(logs, null, 2));
+    });
 };

--- a/test/sale.js
+++ b/test/sale.js
@@ -19,7 +19,7 @@ contract('Sale', (accounts) => {
   const timelocksConf = JSON.parse(fs.readFileSync('./conf/timelocks.json'));
   const saleConf = JSON.parse(fs.readFileSync('./conf/sale.json'));
   const tokenConf = JSON.parse(fs.readFileSync('./conf/token.json'));
-  const logs = JSON.parse(fs.readFileSync('./logs/logs.json'));
+  const logs = JSON.parse(fs.readFileSync('./logs_timelocks/logs_timelocks.json'));
   const [owner, james, miguel, edwhale] = accounts;
 
   let tokensForSale;

--- a/truffle.js
+++ b/truffle.js
@@ -23,19 +23,19 @@ module.exports = {
       provider: new HDWalletProvider(mnemonic, 'https://kovan.infura.io'),
       network_id: '*',
       gas: 4500000,
-      gasPrice: 25000000000,
+      gasPrice: 10000000000,
     },
     rinkeby: {
       provider: new HDWalletProvider(mnemonic, 'https://rinkeby.infura.io'),
       network_id: '*',
       gas: 4500000,
-      gasPrice: 25000000000,
+      gasPrice: 10000000000,
     },
     mainnet: {
       provider: new HDWalletProvider(mnemonic, 'https://mainnet.infura.io'),
       network_id: 1,
       gas: 4500000,
-      gasPrice: 4000000000,
+      gasPrice: 20000000000,
     },
   },
 };


### PR DESCRIPTION
This splits migrations into three separate units:

1. Deploy sale contract
2. Issue `preBuyers` their tokens
3. Deploy timelocked token contracts

Would like a review from @skmgoldin