### PR TITLE
Splits distribution into a separate script

### DIFF
--- a/migrations/2_deploy_sale.js
+++ b/migrations/2_deploy_sale.js
@@ -2,59 +2,6 @@
 
 const Sale = artifacts.require('./Sale.sol');
 const fs = require('fs');
-const BN = require('bn.js');
-
-const distributePreBuyersTokens = async function distributePreBuyersTokens(addresses, tokens) {
-  const BATCHSIZE = 30;
-  if (addresses.length !== tokens.length) {
-    throw new Error('The number of pre-buyers and pre-buyer token allocations do not match');
-  }
-
-  const addressesChunk = addresses.slice(0, BATCHSIZE);
-  const tokensChunk = tokens.slice(0, BATCHSIZE);
-  const sale = await Sale.deployed();
-  await sale.distributePreBuyersRewards(addressesChunk, tokensChunk);
-  console.log(`Distributed tokens to a batch of ${addressesChunk.length} pre-buyers`);
-
-  if (addresses.length <= BATCHSIZE) {
-    return addressesChunk;
-  }
-
-  return addressesChunk.concat(await distributePreBuyersTokens(
-    addresses.slice(BATCHSIZE),
-    tokens.slice(BATCHSIZE),
-  ));
-};
-
-const distributeTimelockedTokens = async function distributeTimeLockedTokens(addresses, tokens,
-  timelocks, periods, logs) {
-  const BATCHSIZE = 4;
-  if (addresses.length !== tokens.length) { // expand
-    throw new Error('The number of pre-buyers and pre-buyer token allocations do not match');
-  }
-
-  const addressesChunk = addresses.slice(0, BATCHSIZE);
-  const tokensChunk = tokens.slice(0, BATCHSIZE);
-  const timelocksChunk = timelocks.slice(0, BATCHSIZE);
-  const periodsChunk = periods.slice(0, BATCHSIZE);
-
-  const sale = await Sale.deployed();
-  const receipt = await sale.distributeTimelockedTokens(addressesChunk, tokensChunk,
-    timelocksChunk, periodsChunk);
-  console.log(`Distributed a batch of ${addressesChunk.length} timelocked token chunks`);
-
-  if (addresses.length <= BATCHSIZE) {
-    return logs.concat(receipt.logs);
-  }
-
-  return distributeTimeLockedTokens(
-    addresses.slice(BATCHSIZE),
-    tokens.slice(BATCHSIZE),
-    timelocks.slice(BATCHSIZE),
-    periods.slice(BATCHSIZE),
-    logs.concat(receipt.logs),
-  );
-};
 
 const flattenTimeLockData = function flattenTimeLockData(timeLockData) {
   const flattenedTimeLockData = {
@@ -85,11 +32,7 @@ module.exports = (deployer) => {
   const tokenConf = JSON.parse(fs.readFileSync('./conf/token.json'));
   const preBuyersConf = JSON.parse(fs.readFileSync('./conf/preBuyers.json'));
   const timelocksConf = JSON.parse(fs.readFileSync('./conf/timelocks.json'));
-
   const preBuyers = Object.keys(preBuyersConf).map(preBuyer => preBuyersConf[preBuyer].address);
-  const preBuyersTokens = Object.keys(preBuyersConf).map(preBuyer =>
-    new BN(preBuyersConf[preBuyer].amount, 10));
-
   const timeLockData = flattenTimeLockData(timelocksConf);
 
   return deployer.deploy(Sale,
@@ -106,19 +49,4 @@ module.exports = (deployer) => {
     timeLockData.beneficiaries.length,
     saleConf.endBlock,
   );
-  /*  .then(() => distributePreBuyersTokens(preBuyers, preBuyersTokens))
-    .then(() => distributeTimelockedTokens(
-      timeLockData.beneficiaries,
-      timeLockData.allocations,
-      timeLockData.disbursementDates,
-      timeLockData.disbursementPeriods,
-      [],
-    ))
-    .then((logs) => {
-      if (!fs.existsSync('logs')) {
-        fs.mkdirSync('logs');
-      }
-      fs.writeFileSync('logs/logs.json', JSON.stringify(logs, null, 2));
-    });
-  */
 };

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "description": "Contracts for fixed-price, finite-supply token sales.",
   "scripts": {
+    "distribute": "truffle exec scripts/distribute.js",
     "test": "node test.js",
     "fix": "eslint --fix",
     "lint": "eslint"

--- a/scripts/distribute.js
+++ b/scripts/distribute.js
@@ -1,5 +1,4 @@
-/* global artifacts */
-
+/* global artifacts*/
 const Sale = artifacts.require('./Sale.sol');
 const fs = require('fs');
 const BN = require('bn.js');
@@ -92,21 +91,7 @@ module.exports = (deployer) => {
 
   const timeLockData = flattenTimeLockData(timelocksConf);
 
-  return deployer.deploy(Sale,
-    saleConf.owner,
-    saleConf.wallet,
-    tokenConf.initialAmount,
-    tokenConf.tokenName,
-    tokenConf.decimalUnits,
-    tokenConf.tokenSymbol,
-    saleConf.price,
-    saleConf.startBlock,
-    saleConf.freezeBlock,
-    preBuyers.length,
-    timeLockData.beneficiaries.length,
-    saleConf.endBlock,
-  );
-  /*  .then(() => distributePreBuyersTokens(preBuyers, preBuyersTokens))
+  distributePreBuyersTokens(preBuyers, preBuyersTokens)
     .then(() => distributeTimelockedTokens(
       timeLockData.beneficiaries,
       timeLockData.allocations,
@@ -120,5 +105,4 @@ module.exports = (deployer) => {
       }
       fs.writeFileSync('logs/logs.json', JSON.stringify(logs, null, 2));
     });
-  */
 };

--- a/scripts/distribute.js
+++ b/scripts/distribute.js
@@ -1,4 +1,5 @@
-/* global artifacts*/
+/* global artifacts */
+
 const Sale = artifacts.require('./Sale.sol');
 const fs = require('fs');
 const BN = require('bn.js');
@@ -79,9 +80,7 @@ const flattenTimeLockData = function flattenTimeLockData(timeLockData) {
   return flattenedTimeLockData;
 };
 
-module.exports = (deployer) => {
-  const saleConf = JSON.parse(fs.readFileSync('./conf/sale.json'));
-  const tokenConf = JSON.parse(fs.readFileSync('./conf/token.json'));
+module.exports = () => {
   const preBuyersConf = JSON.parse(fs.readFileSync('./conf/preBuyers.json'));
   const timelocksConf = JSON.parse(fs.readFileSync('./conf/timelocks.json'));
 


### PR DESCRIPTION
This branch removes distributions from the migrations and puts them in a script, which can be called with `truffle exec`. It is a replacement for #5 and accomplishes the same goal (i.e. allowing distribution of tokens to occur after deployment of the contracts).

This is not yet ready for merge.